### PR TITLE
feat: add hero background image & media optimizations

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,13 @@
   <meta property="og:description" content="Axisies engineers the future with innovative automation, R&amp;D, and advanced engineering solutions across Saudi Arabia." />
   <meta property="og:type" content="website" />
   <meta property="og:url" content="https://ativan-06.github.io/https---github-com-Ativan-06-axisies.github.io/" />
-  <meta property="og:image" content="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1200' height='630' viewBox='0 0 1200 630'%3E%3Crect width='1200' height='630' fill='%230b1220'/%3E%3Ctext x='50%25' y='50%25' fill='%2358a6ff' font-family='system-ui,-apple-system,%22Segoe UI%22,Roboto' font-size='72' text-anchor='middle' dominant-baseline='middle'%3EAxisies%3C/text%3E%3C/svg%3E" />
+  <meta property="og:image" content="https://ativan-06.github.io/axisies.github.io/assets/background.png" />
+  <link
+    rel="preload"
+    as="image"
+    href="https://ativan-06.github.io/axisies.github.io/assets/background.png"
+    imagesrcset="https://ativan-06.github.io/axisies.github.io/assets/background.png 1x"
+  />
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect width='64' height='64' rx='12' ry='12' fill='%230b1220'/%3E%3Cpath d='M20 44L32 12l12 32' stroke='%2358a6ff' stroke-width='4' stroke-linecap='round' stroke-linejoin='round' fill='none'/%3E%3Ccircle cx='32' cy='44' r='4' fill='%23e2e8f0'/%3E%3C/svg%3E" />
   <style>
     :root {
@@ -21,6 +27,7 @@
       --muted: rgba(226, 232, 240, 0.7);
       --font: system-ui, -apple-system, "Segoe UI", Roboto, Ubuntu, Cantarell, "Noto Sans", Arial, sans-serif;
       --shadow: 0 24px 48px rgba(11, 18, 32, 0.45);
+      --hero-bg: url('https://ativan-06.github.io/axisies.github.io/assets/background.png');
       scroll-behavior: smooth;
     }
 
@@ -247,6 +254,11 @@
       display: grid;
       gap: 2.5rem;
       padding: 5rem 0 4rem;
+      background-color: #0b1220;
+      background-image: linear-gradient(rgba(11, 18, 32, 0.8), rgba(11, 18, 32, 0.8)), var(--hero-bg);
+      background-size: cover;
+      background-position: center;
+      background-repeat: no-repeat;
     }
 
     .hero-content {


### PR DESCRIPTION
## Summary
- use a CSS variable to apply the new hero background image with a dark gradient overlay for readability
- preload the hero asset and update the Open Graph image for richer sharing previews

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e119e48a7c8320b4b1724dee21cedb